### PR TITLE
fix: use relative path for script in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,6 @@
 
   <body>
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script type="module" src="src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
The pages deployment was showing a blank white page because the script path in `index.html` was absolute (`/src/main.tsx`). This caused a 404 error when deployed to a subdirectory on GitHub Pages.

This change corrects the path to be relative (`src/main.tsx`), allowing Vite to correctly resolve the path during the build process.