### PR TITLE
fix: add basename to BrowserRouter for GitHub Pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
+      <BrowserRouter basename="/aaronhuff_xyz">
         <Routes>
           <Route path="/" element={<Index />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}


### PR DESCRIPTION
The application was showing a blank page on GitHub Pages because the `BrowserRouter` was not configured with the correct `basename`. This caused the router to not match any routes when the page was loaded in a subdirectory.

This change adds the `basename` prop to the `BrowserRouter` component, with the value `/aaronhuff_xyz`, which is the name of the repository. This will ensure that the router works correctly when the application is deployed to GitHub Pages.