### PR TITLE
fix(Hero): Define roles array to resolve build error

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -7,6 +7,11 @@ import Link from 'next/link';
 const Hero = () => {
   const [displayText, setDisplayText] = useState("");
   const [currentIndex, setCurrentIndex] = useState(0);
+  const roles = [
+    "Network Automation Engineer",
+    "Cloud Solutions Architect",
+    "Python Developer",
+  ];
 
   useEffect(() => {
     const currentRole = roles[currentIndex];


### PR DESCRIPTION
The `Hero.tsx` component was using a variable `roles` without defining it, causing a `TypeError` during the Netlify build process.

This commit defines the `roles` variable as a constant array of strings within the component, directly resolving the build failure. The array is populated with roles that are contextually relevant to the surrounding text.