### PR TITLE
feat: Add _app.tsx to apply global styles

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+/// <reference path="./out/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,6 @@
+import "@/styles/globals.css";
+import type { AppProps } from "next/app";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />;
+}


### PR DESCRIPTION
The application was not loading the global stylesheet because it was missing a custom Next.js App component. This resulted in the page being rendered as plain, unstyled HTML.

This change introduces a `pages/_app.tsx` file, which is the standard way to apply global styles in a Next.js application. The new file imports `styles/globals.css`, ensuring that Tailwind CSS and other global styles are applied correctly across all pages.