### PR TITLE
feat: Add Framer Motion animations and effects

### DIFF
--- a/components/About.tsx
+++ b/components/About.tsx
@@ -1,28 +1,52 @@
 
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
 import { Badge } from "@/components/ui/badge";
 
 const About = () => {
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, amount: 0.2 });
+
+  const variants = {
+    hidden: { opacity: 0, x: -50 },
+    visible: { opacity: 1, x: 0 },
+  };
+
   return (
-    <section id="about" className="py-20 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
-      <div className="text-center mb-16">
-        <h2 className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+    <section id="about" className="py-20 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto" ref={ref}>
+      <motion.div
+        initial="hidden"
+        animate={isInView ? "visible" : "hidden"}
+        variants={{
+          visible: { transition: { staggerChildren: 0.3 } }
+        }}
+        className="text-center mb-16"
+      >
+        <motion.h2 variants={variants} className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
           About Me
-        </h2>
-        <div className="w-24 h-1 bg-gradient-to-r from-blue-500 to-purple-500 mx-auto mb-8"></div>
-      </div>
+        </motion.h2>
+        <motion.div variants={variants} className="w-24 h-1 bg-gradient-to-r from-blue-500 to-purple-500 mx-auto mb-8"></motion.div>
+      </motion.div>
       
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
-        <div className="space-y-6">
-          <p className="text-lg text-gray-300 leading-relaxed">
+        <motion.div
+          initial="hidden"
+          animate={isInView ? "visible" : "hidden"}
+          variants={{
+            visible: { transition: { staggerChildren: 0.3 } }
+          }}
+          className="space-y-6"
+        >
+          <motion.p variants={variants} className="text-lg text-gray-300 leading-relaxed">
             With over 5 years of experience in network automation and cloud-native development, 
             I specialize in bridging the gap between traditional networking and modern cloud infrastructure.
-          </p>
-          <p className="text-lg text-gray-300 leading-relaxed">
+          </motion.p>
+          <motion.p variants={variants} className="text-lg text-gray-300 leading-relaxed">
             My expertise spans from automating complex network configurations with Python and Ansible 
             to deploying scalable applications on Kubernetes. I'm passionate about Infrastructure as Code 
             and believe in the power of automation to solve real-world problems.
-          </p>
-          <div className="grid grid-cols-2 gap-4 mt-8">
+          </motion.p>
+          <motion.div variants={variants} className="grid grid-cols-2 gap-4 mt-8">
             <div className="text-center p-4 bg-white/5 rounded-lg backdrop-blur-sm">
               <div className="text-3xl font-bold text-blue-400">20+</div>
               <div className="text-gray-400">Projects Completed</div>
@@ -31,13 +55,20 @@ const About = () => {
               <div className="text-3xl font-bold text-purple-400">15+</div>
               <div className="text-gray-400">Years Experience</div>
             </div>
-          </div>
-        </div>
+          </motion.div>
+        </motion.div>
         
-        <div className="space-y-6">
-          <h3 className="text-2xl font-semibold text-white mb-4">Tech Stack</h3>
+        <motion.div
+          initial="hidden"
+          animate={isInView ? "visible" : "hidden"}
+          variants={{
+            visible: { transition: { staggerChildren: 0.1 } }
+          }}
+          className="space-y-6"
+        >
+          <motion.h3 variants={variants} className="text-2xl font-semibold text-white mb-4">Tech Stack</motion.h3>
           <div className="space-y-4">
-            <div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">Programming Languages</h4>
               <div className="flex flex-wrap gap-2">
                 {["Python", "Bash", "PowerShell"].map((tech) => (
@@ -46,8 +77,8 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
-            <div>
+            </motion.div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">Network Protocols</h4>
               <div className="flex flex-wrap gap-2">
                 {["BGP", "OSPF", "EIGRP", "RIP"].map((tech) => (
@@ -56,8 +87,8 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
-            <div>
+            </motion.div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">Automation & IaC</h4>
               <div className="flex flex-wrap gap-2">
                 {["Ansible", "Terraform", "Nautobot", "CI/CD", "GitHub Actions"].map((tech) => (
@@ -66,8 +97,8 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
-            <div>
+            </motion.div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">Cloud & Container Platforms</h4>
               <div className="flex flex-wrap gap-2">
                 {["Azure", "Oracle Cloud", "Kubernetes", "Docker"].map((tech) => (
@@ -76,8 +107,8 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
-            <div>
+            </motion.div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">Network Platforms</h4>
               <div className="flex flex-wrap gap-2">
                 {["Cisco IOS", "Cisco NXOS", "Versa SD-WAN", "Cisco DNA Center", "Versa Director"].map((tech) => (
@@ -86,8 +117,8 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
-            <div>
+            </motion.div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">Enterprise Tools & DevOps</h4>
               <div className="flex flex-wrap gap-2">
                 {["Infoblox", "ServiceNow", "GitHub", "Git", "Azure DevOps"].map((tech) => (
@@ -96,8 +127,8 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
-            <div>
+            </motion.div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">Agile & Project Management</h4>
               <div className="flex flex-wrap gap-2">
                 {["Scrum Master", "Sprint Planning", "Sprint Reviews", "Retrospectives"].map((tech) => (
@@ -106,8 +137,8 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
-            <div>
+            </motion.div>
+            <motion.div variants={variants}>
               <h4 className="text-lg font-medium text-gray-300 mb-2">AI Development</h4>
               <div className="flex flex-wrap gap-2">
                 {["Agentic AI Development", "Large Language Models", "Prompt Engineering"].map((tech) => (
@@ -116,9 +147,9 @@ const About = () => {
                   </Badge>
                 ))}
               </div>
-            </div>
+            </motion.div>
           </div>
-        </div>
+        </motion.div>
       </div>
     </section>
   );

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,4 +1,6 @@
-import { Mail, MapPin, Phone } from "lucide-react";
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
+import { Mail, MapPin } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const Contact = () => {
@@ -8,19 +10,40 @@ const Contact = () => {
     window.open(`mailto:aaron.t.huff@gmail.com?subject=${subject}&body=${body}`, '_blank');
   };
 
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, amount: 0.2 });
+
+  const variants = {
+    hidden: { opacity: 0, y: 50 },
+    visible: { opacity: 1, y: 0 },
+  };
+
   return (
-    <section id="contact" className="py-20 px-4 sm:px-6 lg:px-8">
+    <section id="contact" className="py-20 px-4 sm:px-6 lg:px-8" ref={ref}>
       <div className="max-w-4xl mx-auto">
-        <div className="text-center mb-12">
-          <h2 className="text-4xl font-bold text-white mb-4">Let's Connect</h2>
-          <p className="text-xl text-gray-400">
+        <motion.div
+          initial="hidden"
+          animate={isInView ? "visible" : "hidden"}
+          variants={{
+            visible: { transition: { staggerChildren: 0.3 } }
+          }}
+          className="text-center mb-12"
+        >
+          <motion.h2 variants={variants} className="text-4xl font-bold text-white mb-4">Let's Connect</motion.h2>
+          <motion.p variants={variants} className="text-xl text-gray-400">
             Have a project in mind or want to discuss opportunities? I'd love to hear from you.
-          </p>
-        </div>
+          </motion.p>
+        </motion.div>
         
         <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
           {/* Contact Info */}
-          <div className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700">
+          <motion.div
+            initial="hidden"
+            animate={isInView ? "visible" : "hidden"}
+            variants={variants}
+            transition={{ duration: 0.5, delay: 0.2 }}
+            className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700"
+          >
             <h3 className="text-2xl font-semibold text-white mb-6">Get in Touch</h3>
             <div className="space-y-6">
               <div className="flex items-center space-x-4">
@@ -48,23 +71,31 @@ const Contact = () => {
                 </div>
               </div>
             </div>
-          </div>
+          </motion.div>
 
           {/* Contact CTA */}
-          <div className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700 flex flex-col justify-center">
+          <motion.div
+            initial="hidden"
+            animate={isInView ? "visible" : "hidden"}
+            variants={variants}
+            transition={{ duration: 0.5, delay: 0.4 }}
+            className="bg-gray-800/50 backdrop-blur-sm rounded-2xl p-8 border border-gray-700 flex flex-col justify-center"
+          >
             <h3 className="text-2xl font-semibold text-white mb-4">Ready to Start a Project?</h3>
             <p className="text-gray-400 mb-8">
               Whether you need network automation, cloud infrastructure, or DevOps solutions, 
               I'm here to help transform your ideas into reality.
             </p>
-            <Button
-              onClick={handleEmailClick}
-              className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white py-4 px-8 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105"
-            >
-              <Mail className="mr-2 h-5 w-5" />
-              Send me an Email
-            </Button>
-          </div>
+            <motion.div whileHover={{ scale: 1.05, y: -5, boxShadow: "0px 10px 20px rgba(0, 0, 0, 0.4)" }}>
+              <Button
+                onClick={handleEmailClick}
+                className="bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white py-4 px-8 rounded-lg font-semibold transition-all duration-300 w-full"
+              >
+                <Mail className="mr-2 h-5 w-5" />
+                Send me an Email
+              </Button>
+            </motion.div>
+          </motion.div>
         </div>
       </div>
     </section>

--- a/components/Navigation.tsx
+++ b/components/Navigation.tsx
@@ -1,5 +1,8 @@
 
 import Link from 'next/link';
+import { motion } from 'framer-motion';
+
+const MotionLink = motion(Link);
 
 const Navigation = () => {
   return (
@@ -10,10 +13,10 @@ const Navigation = () => {
             aaronhuff.xyz
           </Link>
           <div className="hidden md:flex space-x-8">
-            <Link href="/#about" className="text-gray-300 hover:text-white transition-colors">About</Link>
-            <Link href="/#projects" className="text-gray-300 hover:text-white transition-colors">Projects</Link>
-            <Link href="/#contact" className="text-gray-300 hover:text-white transition-colors">Contact</Link>
-            <Link href="/blog" className="text-gray-300 hover:text-white transition-colors">Blog</Link>
+            <MotionLink href="/#about" className="text-gray-300 hover:text-white transition-colors" whileHover={{ scale: 1.1 }}>About</MotionLink>
+            <MotionLink href="/#projects" className="text-gray-300 hover:text-white transition-colors" whileHover={{ scale: 1.1 }}>Projects</MotionLink>
+            <MotionLink href="/#contact" className="text-gray-300 hover:text-white transition-colors" whileHover={{ scale: 1.1 }}>Contact</MotionLink>
+            <MotionLink href="/blog" className="text-gray-300 hover:text-white transition-colors" whileHover={{ scale: 1.1 }}>Blog</MotionLink>
           </div>
         </div>
       </div>

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -1,4 +1,6 @@
 
+import { useRef } from 'react';
+import { motion, useInView } from 'framer-motion';
 import { Github, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -29,55 +31,91 @@ const Projects = () => {
     }
   ];
 
+  const ref = useRef(null);
+  const isInView = useInView(ref, { once: true, amount: 0.2 });
+
+  const cardVariants = {
+    hidden: { opacity: 0, y: 50 },
+    visible: { opacity: 1, y: 0 },
+  };
+
   return (
-    <section id="projects" className="py-20 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto">
-      <div className="text-center mb-16">
-        <h2 className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
+    <section id="projects" className="py-20 px-4 sm:px-6 lg:px-8 max-w-7xl mx-auto" ref={ref}>
+      <motion.div
+        initial="hidden"
+        animate={isInView ? "visible" : "hidden"}
+        variants={{
+          visible: { transition: { staggerChildren: 0.3 } }
+        }}
+        className="text-center mb-16"
+      >
+        <motion.h2 variants={cardVariants} className="text-4xl md:text-5xl font-bold mb-6 bg-gradient-to-r from-blue-400 to-purple-400 bg-clip-text text-transparent">
           Featured Projects
-        </h2>
-        <div className="w-24 h-1 bg-gradient-to-r from-blue-500 to-purple-500 mx-auto mb-8"></div>
-        <p className="text-xl text-gray-400 max-w-2xl mx-auto">
+        </motion.h2>
+        <motion.div variants={cardVariants} className="w-24 h-1 bg-gradient-to-r from-blue-500 to-purple-500 mx-auto mb-8"></motion.div>
+        <motion.p variants={cardVariants} className="text-xl text-gray-400 max-w-2xl mx-auto">
           Here are some of my recent projects that showcase my expertise in network automation and cloud-native development.
-        </p>
-      </div>
+        </motion.p>
+      </motion.div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
         {projects.map((project, index) => (
-          <Card key={index} className="bg-white/5 border-gray-700 hover:bg-white/10 transition-all duration-300 transform hover:scale-105 group">
-            <CardContent className="p-6">
-              <h3 className="text-xl font-semibold text-white mb-3 group-hover:text-blue-400 transition-colors">
-                {project.title}
-              </h3>
-              <p className="text-gray-400 mb-4 leading-relaxed">
-                {project.description}
-              </p>
-              <div className="flex flex-wrap gap-2 mb-6">
-                {project.tech.map((tech) => (
-                  <Badge key={tech} variant="outline" className="border-gray-600 text-gray-300">
-                    {tech}
-                  </Badge>
-                ))}
-              </div>
-              <div className="flex gap-4">
-                {project.github !== "#" && (
-                  <Button variant="outline" size="sm" className="border-gray-600 text-gray-300 hover:bg-white hover:text-black" asChild>
-                    <a href={project.github} target="_blank" rel="noopener noreferrer">
-                      <Github className="mr-2 h-4 w-4" />
-                      Code
-                    </a>
-                  </Button>
-                )}
-                {project.demo !== "#" && (
-                  <Button variant="outline" size="sm" className="border-gray-600 text-gray-300 hover:bg-white hover:text-black" asChild>
-                    <a href={project.demo} target="_blank" rel="noopener noreferrer">
-                      <ExternalLink className="mr-2 h-4 w-4" />
-                      Visit Site
-                    </a>
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <motion.div
+            key={index}
+            initial="hidden"
+            animate={isInView ? "visible" : "hidden"}
+            variants={cardVariants}
+            transition={{ duration: 0.5, delay: index * 0.2 }}
+            whileHover={{ scale: 1.05, boxShadow: "0px 10px 30px rgba(0, 0, 0, 0.5)" }}
+          >
+            <Card className="bg-white/5 border-gray-700 group h-full">
+              <CardContent className="p-6 flex flex-col h-full">
+                <h3 className="text-xl font-semibold text-white mb-3 group-hover:text-blue-400 transition-colors">
+                  {project.title}
+                </h3>
+                <p className="text-gray-400 mb-4 leading-relaxed flex-grow">
+                  {project.description}
+                </p>
+                <div className="flex flex-wrap gap-2 mb-6">
+                  {project.tech.map((tech) => (
+                    <Badge key={tech} variant="outline" className="border-gray-600 text-gray-300">
+                      {tech}
+                    </Badge>
+                  ))}
+                </div>
+                <div className="flex gap-4 mt-auto">
+                  {project.github !== "#" && (
+                    <motion.a
+                      href={project.github}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      whileHover={{ scale: 1.1, y: -2 }}
+                      className="inline-block"
+                    >
+                      <Button variant="outline" size="sm" className="border-gray-600 text-gray-300 hover:bg-white hover:text-black">
+                        <Github className="mr-2 h-4 w-4" />
+                        Code
+                      </Button>
+                    </motion.a>
+                  )}
+                  {project.demo !== "#" && (
+                    <motion.a
+                      href={project.demo}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      whileHover={{ scale: 1.1, y: -2 }}
+                      className="inline-block"
+                    >
+                      <Button variant="outline" size="sm" className="border-gray-600 text-gray-300 hover:bg-white hover:text-black">
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        Visit Site
+                      </Button>
+                    </motion.a>
+                  )}
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
         ))}
       </div>
     </section>

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "framer-motion": "^12.23.12",
         "gray-matter": "^4.0.3",
         "input-otp": "^1.2.4",
         "lucide-react": "^0.462.0",
@@ -6732,6 +6733,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
+      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs-extra": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
@@ -9133,6 +9161,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
+    "framer-motion": "^12.23.12",
     "gray-matter": "^4.0.3",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.462.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,4 +1,6 @@
 
+import { useRef } from 'react';
+import { motion, useScroll, useTransform } from 'framer-motion';
 import Navigation from '@/components/Navigation';
 import Hero from '@/components/Hero';
 import About from '@/components/About';
@@ -7,19 +9,29 @@ import Contact from '@/components/Contact';
 import Footer from '@/components/Footer';
 
 const Index = () => {
+  const ref = useRef(null);
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start start", "end start"]
+  });
+
+  const backgroundY = useTransform(scrollYProgress, [0, 1], ["0%", "50%"]);
+
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
+    <div ref={ref} className="min-h-screen bg-gradient-to-br from-slate-900 via-purple-900 to-slate-900">
       <Navigation />
       <Hero />
-      <div id="about">
-        <About />
-      </div>
-      <div id="projects">
-        <Projects />
-      </div>
-      <div id="contact">
-        <Contact />
-      </div>
+      <motion.div style={{ y: backgroundY }}>
+        <div id="about">
+          <About />
+        </div>
+        <div id="projects">
+          <Projects />
+        </div>
+        <div id="contact">
+          <Contact />
+        </div>
+      </motion.div>
       <Footer />
     </div>
   );


### PR DESCRIPTION
This commit introduces several animations and effects to enhance the user experience of the portfolio website, using the Framer Motion library.

The following changes have been implemented:

1.  **Parallax Effect**: The main content sections now have a parallax scrolling effect, creating a sense of depth as the user scrolls. This was achieved by using the `useScroll` and `useTransform` hooks from Framer Motion in the main page component.

2.  **On-Scroll Animations**: Content elements in the "About", "Projects", and "Contact" sections now fade in and slide into view as they enter the viewport. This is implemented using the `useInView` hook and `motion.div` components with variants.

3.  **Hover Effects**:
    -   Navigation links now scale up slightly on hover.
    -   Project cards and buttons now have a "lift" effect on hover, with a subtle scaling and box-shadow animation.

All animations have been visually verified.

Note: The `npm run lint` command failed due to a deprecation issue with `next lint`. This appears to be a pre-existing tooling configuration problem and is unrelated to the animation changes.