### PR TITLE
fix: add favicon link to head

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,14 @@
 import "@/styles/globals.css";
 import type { AppProps } from "next/app";
+import Head from "next/head";
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <>
+      <Head>
+        <link rel="icon" href="/favicon.svg" />
+      </Head>
+      <Component {...pageProps} />
+    </>
+  );
 }


### PR DESCRIPTION
This pull request makes a small improvement to the application by ensuring that a favicon is included on all pages.

* Added a `<Head>` component to `_app.tsx` to include a favicon (`/favicon.svg`) for the entire app.