### PR TITLE
fix(css): revert background to show animated gradient

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+/// <reference path="./out/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -103,8 +103,7 @@
   }
 
   body {
-    @apply text-foreground;
-    background: linear-gradient(90deg, #312e81 0%, #6d28d9 100%);
+    @apply bg-background text-foreground;
     overflow-x: hidden; /* Prevents horizontal scrolling */
   }
 }


### PR DESCRIPTION
The body background was overridden with a bright purple gradient, hiding the intended animated background in the Hero section.

This change removes the override in `styles/globals.css` and applies the theme's background color to the body, allowing the animated gradient to be visible.