### PR TITLE
fix: decode favicon.svg content

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,3 +1,3 @@
-<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22>
-  <text y=%22.9em%22 font-size=%2290%22>👾</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <text y=".9em" font-size="90">👾</text>
 </svg>


### PR DESCRIPTION
The favicon.svg file contained URL-encoded SVG markup, which prevented it from rendering correctly in browsers. This commit decodes the SVG content to standard SVG/XML format, allowing the space invader emoji to be displayed as the site's favicon.